### PR TITLE
The retry strategy is not a property of the farm, and should belong to each pipeline

### DIFF
--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -6,7 +6,7 @@ params {
 }
 
 // Queue and retry strategy
-process{
+process {
     executor = 'lsf'
     queue = { task.time < 12.h ? 'normal' : task.time < 48.h ? 'long' : task.time < 168.h ? 'week' : 'basement' }
     errorStrategy = 'retry'
@@ -14,7 +14,7 @@ process{
 }
 
 // Executor details
-executor{
+executor {
     name = 'lsf'
     perJobMemLimit = true
     poolSize = 4

--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -5,12 +5,10 @@ params {
     config_profile_url = 'https://www.sanger.ac.uk'
 }
 
-// Queue and retry strategy
+// Executor and queue selection
 process {
     executor = 'lsf'
     queue = { task.time < 12.h ? 'normal' : task.time < 48.h ? 'long' : task.time < 168.h ? 'week' : 'basement' }
-    errorStrategy = 'retry'
-    maxRetries = 5
 }
 
 // Executor details


### PR DESCRIPTION
I think this config should only be able the LSF environment. The retry strategy / max count is a decision that each pipeline developer needs to make for their pipeline (ideally taking other factors into account, like the exit code)